### PR TITLE
Stop root path possibility from metadata filename

### DIFF
--- a/cart/cart.py
+++ b/cart/cart.py
@@ -604,7 +604,7 @@ def main():
                             backup_name = backup_name[:-5]
                         else:
                             backup_name += ".uncart"
-                        output_file = cur_metadata.get("name", backup_name)
+                        output_file = cur_metadata.get("name", backup_name).lstrip("/")
                     output_file = os.path.join(os.path.dirname(cur_file), output_file)
 
                     if os.path.exists(output_file) and not force:


### PR DESCRIPTION
Leaving the possibility for a user to provide a full rooted path using the --outfile option on the commandline.